### PR TITLE
Set application name to full version: NZSL Dictionary

### DIFF
--- a/NZSLDict/NZSLDict-Info.plist
+++ b/NZSLDict/NZSLDict-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>NZSL Dictionary</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
For reasons that I suspect date back to the fact that this application started as an unofficial release, the application has always been named 'NZSLDict'. Given this app's been in the ODNZSL fold for some time, it seems worthwhile to name the application consistently with the rest of the apps (web, Android)