### PR TITLE
Update dictionary to Signbank release 2023-02-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,28 @@
 
 This repository holds the code necessary to develop the NZSL Dictionary App for iOS. This codebase can be imported into XCode and you are invited to fork it to add features and bug fixes.
 
-The original code was developed by [Greg Hewgill](http://hewgill.com/) and generously gifted to the [Deaf Studies Research Unit](http://www.victoria.ac.nz/lals/centres-and-institutes/dsru) of [Victoria University of Wellington](http://www.victoria.ac.nz/). It is maintained by [Ackama](https://www.ackama.com/). 
+The original code was developed by [Greg Hewgill](http://hewgill.com/) and generously gifted to the [Deaf Studies Research Unit](http://www.victoria.ac.nz/lals/centres-and-institutes/dsru) of [Victoria University of Wellington](http://www.victoria.ac.nz/). It is maintained by [Ackama](https://www.ackama.com/).
+
+# Dictionary data
+
+The dictionary is updated monthly, with data released publicly at https://github.com/ODNZSL/nzsl-dictionary-scripts/releases.
+
+While we keep a version of the dictionary database up-to-date in this repository, you
+can download the latest version at any time by placing the "nzsl.dat" file in `app/src/main/assets/db/nzsl.dat`.
 
 # Missing images?
 
-This repository does not include images for the database of signs. We have created [an importer script](https://github.com/ODNZSL/nzsl-dictionary-scripts) that will fetch the latest images from the VUW servers and place them in the correct folder. You should run this once when you start development. Signs are updated every few months.
+This repository does not include images for the database of signs. Just like the dictionary data, we prepare a public export of published sign data monthly, including preprocessed images for use in the native Android and iOS apps.
+
+Find the latest release at https://github.com/ODNZSL/nzsl-dictionary-scripts/release, from which you can download `assets.tar.gz`, and place the extracted 'assets' folder at `app/src/main/assets/images/signs`.
+
+e.g.
+
+```
+tar -xf assets.tar.gz
+rm -r app/src/main/assets/images/signs
+mv assets app/src/main/assets/images/signs
+```
 
 # Android and iOS features
 
@@ -20,14 +37,14 @@ If you find a bug and would like to report it, please open a Github issue. If yo
 
 # Contributions
 
-Contributions are welcome for this project. Please comment on an issue if you are willing to work on it and an administrator will give you further information if required. 
+Contributions are welcome for this project. Please comment on an issue if you are willing to work on it and an administrator will give you further information if required.
 To contribute, make a fork of this repository and branch off the master branch.
 Create a pull request against the ODNZSL master branch.
 Two approvals are required before a PR can be merged.
 
 # Deployment
 
-To deploy to production: merge a feature branch into ODNZSL master.
+To deploy to production: merge a feature branch into ODNZSL main.
 A repository administrator will perform the necessary actions when a release is planned.
 
 # License


### PR DESCRIPTION
This pull request updates the Signbank database to [version 2023-02-01](https://github.com/ODNZSL/nzsl-dictionary-scripts/releases/tag/signbank-2023-02-01). 

Since this is the first time we are updating the iOS app to use Signbank data, it also updates the README to describe the new process to access dictionary assets (database and images)